### PR TITLE
feat: autenticacao JWT no service_manager (#73)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8002:8002"
+    environment:
+      - JWT_SECRET=${JWT_SECRET:-dev-secret-change-me}
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@procon.sp.gov.br}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin123}
+    volumes:
+      - ./services/service_manager/data:/app/data
     networks:
       - assistente-whatsapp-net
 

--- a/services/service_manager/.gitignore
+++ b/services/service_manager/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+data/
+.env

--- a/services/service_manager/Dockerfile
+++ b/services/service_manager/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
 
+RUN mkdir -p data
+
 EXPOSE 8002
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/services/service_manager/app/database.py
+++ b/services/service_manager/app/database.py
@@ -1,0 +1,25 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./data/service_manager.db")
+
+if DATABASE_URL.startswith("sqlite:///"):
+    db_path = DATABASE_URL.removeprefix("sqlite:///")
+    db_dir = os.path.dirname(db_path)
+    if db_dir:
+        os.makedirs(db_dir, exist_ok=True)
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/service_manager/app/deps.py
+++ b/services/service_manager/app/deps.py
@@ -1,0 +1,24 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError
+from sqlalchemy.orm import Session
+
+from app import models, security
+from app.database import get_db
+
+bearer_scheme = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> models.User:
+    try:
+        user_id = security.decode_access_token(credentials.credentials)
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido")
+
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado")
+    return user

--- a/services/service_manager/app/main.py
+++ b/services/service_manager/app/main.py
@@ -1,6 +1,32 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.database import Base, SessionLocal, engine
+from app.routers import auth
+from app.seed import seed_default_admin
+
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Service Manager", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    db = SessionLocal()
+    try:
+        seed_default_admin(db)
+    finally:
+        db.close()
 
 
 @app.get("/api/v1/health")

--- a/services/service_manager/app/models.py
+++ b/services/service_manager/app/models.py
@@ -1,0 +1,22 @@
+import enum
+import uuid
+
+from sqlalchemy import Column, Enum as SAEnum, String
+
+from app.database import Base
+
+
+class Role(str, enum.Enum):
+    gestor_gerencia = "gestor_gerencia"
+    gestor_analista = "gestor_analista"
+    analista = "analista"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, nullable=False, index=True)
+    hashed_password = Column(String, nullable=False)
+    role = Column(SAEnum(Role), nullable=False)

--- a/services/service_manager/app/routers/auth.py
+++ b/services/service_manager/app/routers/auth.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import models, schemas, security
+from app.database import get_db
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=schemas.TokenResponse)
+def login(payload: schemas.LoginRequest, db: Session = Depends(get_db)) -> schemas.TokenResponse:
+    user = db.query(models.User).filter(models.User.email == payload.email).first()
+    if not user or not security.verify_password(payload.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="E-mail ou senha inválidos",
+        )
+
+    token = security.create_access_token(subject=user.id)
+    return schemas.TokenResponse(token=token, user=schemas.UserOut.model_validate(user))

--- a/services/service_manager/app/schemas.py
+++ b/services/service_manager/app/schemas.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, ConfigDict, EmailStr
+
+from app.models import Role
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    email: EmailStr
+    role: Role
+
+
+class TokenResponse(BaseModel):
+    token: str
+    user: UserOut

--- a/services/service_manager/app/security.py
+++ b/services/service_manager/app/security.py
@@ -1,0 +1,29 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+from jose import jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = os.getenv("JWT_SECRET", "dev-secret-change-me")
+ALGORITHM = "HS256"
+TOKEN_EXPIRE_SECONDS = 8 * 60 * 60  # 8h, matches frontend auth cookie
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(seconds=TOKEN_EXPIRE_SECONDS)
+    return jwt.encode({"sub": subject, "exp": expire}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> str:
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    return payload["sub"]

--- a/services/service_manager/app/seed.py
+++ b/services/service_manager/app/seed.py
@@ -1,0 +1,22 @@
+import os
+
+from sqlalchemy.orm import Session
+
+from app import models, security
+
+
+def seed_default_admin(db: Session) -> None:
+    if db.query(models.User).count() > 0:
+        return
+
+    email = os.getenv("ADMIN_EMAIL", "admin@procon.sp.gov.br")
+    password = os.getenv("ADMIN_PASSWORD", "admin123")
+
+    admin = models.User(
+        name="Administrador",
+        email=email,
+        hashed_password=security.hash_password(password),
+        role=models.Role.gestor_gerencia,
+    )
+    db.add(admin)
+    db.commit()

--- a/services/service_manager/requirements.txt
+++ b/services/service_manager/requirements.txt
@@ -1,2 +1,7 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
+sqlalchemy==2.0.35
+passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
+python-jose[cryptography]==3.3.0
+email-validator==2.2.0


### PR DESCRIPTION
## Resumo
- Endpoint `POST /auth/login`: valida email/senha (bcrypt) e retorna JWT (8h) + dados do usuario
- Modelo `User`/`Role` (SQLAlchemy + SQLite local)
- `get_current_user`: dependencia para proteger rotas via Bearer token
- Seed do admin padrao (`admin@procon.sp.gov.br` / `admin123`, configuravel via env) no startup

Closes #73