### PR TITLE
feat: CRUD de usuarios admin com roles (#74)

### DIFF
--- a/services/service_manager/app/main.py
+++ b/services/service_manager/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import Base, SessionLocal, engine
-from app.routers import auth
+from app.routers import auth, users
 from app.seed import seed_default_admin
 
 Base.metadata.create_all(bind=engine)
@@ -18,6 +18,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router)
+app.include_router(users.router)
 
 
 @app.on_event("startup")

--- a/services/service_manager/app/routers/users.py
+++ b/services/service_manager/app/routers/users.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import models, schemas, security
+from app.database import get_db
+from app.deps import get_current_user
+
+router = APIRouter(prefix="/api/v1/admin-users", tags=["admin-users"])
+
+
+@router.get("", response_model=list[schemas.UserOut])
+def list_users(
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+) -> list[models.User]:
+    return db.query(models.User).all()
+
+
+@router.post("", response_model=schemas.UserOut, status_code=status.HTTP_201_CREATED)
+def create_user(
+    payload: schemas.UserCreate,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+) -> models.User:
+    if db.query(models.User).filter(models.User.email == payload.email).first():
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="E-mail já cadastrado")
+
+    user = models.User(
+        name=payload.name,
+        email=payload.email,
+        hashed_password=security.hash_password(payload.password),
+        role=payload.role,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.put("/{user_id}", response_model=schemas.UserOut)
+def update_user(
+    user_id: str,
+    payload: schemas.UserUpdate,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+) -> models.User:
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
+
+    existing = (
+        db.query(models.User)
+        .filter(models.User.email == payload.email, models.User.id != user_id)
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="E-mail já cadastrado")
+
+    user.name = payload.name
+    user.email = payload.email
+    user.role = payload.role
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(get_current_user),
+) -> None:
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
+
+    db.delete(user)
+    db.commit()

--- a/services/service_manager/app/schemas.py
+++ b/services/service_manager/app/schemas.py
@@ -17,6 +17,19 @@ class UserOut(BaseModel):
     role: Role
 
 
+class UserCreate(BaseModel):
+    name: str
+    email: EmailStr
+    password: str
+    role: Role
+
+
+class UserUpdate(BaseModel):
+    name: str
+    email: EmailStr
+    role: Role
+
+
 class TokenResponse(BaseModel):
     token: str
     user: UserOut


### PR DESCRIPTION
## Resumo
- `/api/v1/admin-users`: GET (lista), POST (cria), PUT/DELETE por id
- Validacao de email unico (409 em conflito)
- Protegido por `get_current_user` (Bearer token)
- Suporte aos papeis `gestor_gerencia`, `gestor_analista`, `analista`

> Empilhada sobre #75 (auth/#73) — depende dela. Mergear #75 primeiro.

Renomeado de `/api/v1/users` para `/api/v1/admin-users` para evitar
colisao com endpoints de clientes/WhatsApp (`/api/v1/users`) de outro
modulo do service_manager.

Closes #74