### PR TITLE
feat: coleta de nome e CPF reais dos clientes

### DIFF
--- a/services/service_manager/app/main.py
+++ b/services/service_manager/app/main.py
@@ -1,12 +1,20 @@
 from contextlib import asynccontextmanager
+from typing import Optional
+
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 from sqlmodel import Session, select
 from .database import create_db_and_tables, engine, get_session
 from .models.entities import User, Conversation, Message, Feedback
 from .routers import auth, users
 from .seed import seed_default_admin
-from .utils.security import decrypt_data
+from .utils.security import decrypt_data, encrypt_data
+
+
+class UserUpdate(BaseModel):
+    name: Optional[str] = None
+    cpf: Optional[str] = None
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -72,6 +80,25 @@ def get_user_by_phone(phone: str, session: Session = Depends(get_session)):
     user = session.exec(statement).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.put("/api/v1/users/{user_id}", response_model=User)
+def update_user(user_id: int, payload: UserUpdate, session: Session = Depends(get_session)):
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if payload.name is not None:
+        user.name = payload.name
+    if payload.cpf is not None:
+        user.cpf = encrypt_data(payload.cpf)
+
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    user.cpf = decrypt_data(user.cpf)
     return user
 
 

--- a/services/whatsapp_bot/index.js
+++ b/services/whatsapp_bot/index.js
@@ -103,6 +103,23 @@ async function saveFeedback(conversationId, rating) {
     }
 }
 
+// Coleta de dados reais do cliente (nome/CPF), substituindo o placeholder inicial
+const onboardingState = new Map(); // phone -> { step: 'name' | 'cpf', name?: string }
+
+function isValidCpf(value) {
+    return value.replace(/\D/g, '').length === 11;
+}
+
+async function updateUserData(userId, data) {
+    try {
+        await axios.put(`${MANAGER_URL}/users/${userId}`, data);
+        return true;
+    } catch (error) {
+        console.error('Erro ao atualizar dados do cliente:', error.message);
+        return false;
+    }
+}
+
 // ... (Client initialization)
 const client = new Client({
     authStrategy: new LocalAuth(),
@@ -148,6 +165,33 @@ client.on('message', async (msg) => {
         return;
     }
 
+    // 2. Continuação da coleta de dados (nome/CPF), se já iniciada para este número
+    const onboardingPhone = msg.from.split('@')[0];
+    const onboarding = onboardingState.get(onboardingPhone);
+
+    if (onboarding) {
+        if (onboarding.step === 'name') {
+            onboarding.name = msg.body.trim();
+            onboarding.step = 'cpf';
+            await msg.reply('Obrigado! Agora informe seu CPF (apenas números).');
+            return;
+        }
+
+        if (onboarding.step === 'cpf') {
+            if (!isValidCpf(msg.body)) {
+                await msg.reply('CPF inválido. Por favor, envie os 11 números do seu CPF.');
+                return;
+            }
+
+            const user = await getOrCreateUser(onboardingPhone);
+            await updateUserData(user.id, { name: onboarding.name, cpf: msg.body.replace(/\D/g, '') });
+            onboardingState.delete(onboardingPhone);
+
+            await msg.reply('Dados confirmados! Agora me conte como posso te ajudar (mencione "procon" na sua mensagem).');
+            return;
+        }
+    }
+
     // Trava de segurança: só responde se a mensagem contiver "procon" (case insensitive)
     if (!msg.body.toLowerCase().includes('procon')) {
         return;
@@ -160,6 +204,14 @@ client.on('message', async (msg) => {
         const contact = await msg.getContact();
         const phone = contact.id.user; // O número real está aqui
         const user = await getOrCreateUser(phone);
+
+        // Inicia a coleta de nome/CPF reais antes de seguir com o atendimento
+        if (!user.cpf) {
+            onboardingState.set(phone, { step: 'name' });
+            await msg.reply('Olá! Sou o assistente virtual do Procon Jacareí. Antes de continuar, preciso confirmar alguns dados.\n\nQual o seu nome completo?');
+            return;
+        }
+
         const conversation = await getOrCreateConversation(user.id);
 
         // 2. Salvar mensagem do usuário no banco


### PR DESCRIPTION
## Summary
- Adiciona `PUT /api/v1/users/{user_id}` para atualizar nome/CPF de um cliente, com criptografia do CPF (`encrypt_data`/`decrypt_data`).
- Adiciona fluxo de onboarding no `whatsapp_bot`: no primeiro contato, o bot pede nome e CPF reais do cliente (validando 11 dígitos) antes de seguir para o fluxo normal de atendimento, substituindo os dados placeholder (`name="Cliente WhatsApp"`, `cpf=""`).

## Test plan
- [x] `PUT /api/v1/users/{id}` testado via curl (nome/CPF atualizados, CPF criptografado no banco e descriptografado na resposta)
- [x] Fluxo de onboarding testado via WhatsApp Web (cliente novo é questionado sobre nome/CPF antes do fluxo "procon")