### PR TITLE
feat: avaliação de respostas da LLM por gestores e analistas

### DIFF
--- a/services/service_manager/app/database.py
+++ b/services/service_manager/app/database.py
@@ -12,7 +12,7 @@ engine = create_engine(DATABASE_URL, echo=True)
 
 
 def create_db_and_tables():
-    from .models.entities import User, Conversation, Message, Feedback  # Import to ensure they are registered
+    from .models.entities import User, Conversation, Message, Feedback, MessageEvaluation  # Import to ensure they are registered
     from .models.admin import AdminUser  # Import to ensure it is registered
 
     max_retries = 5

--- a/services/service_manager/app/main.py
+++ b/services/service_manager/app/main.py
@@ -1,12 +1,14 @@
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from sqlmodel import Session, select
 from .database import create_db_and_tables, engine, get_session
-from .models.entities import User, Conversation, Message, Feedback
+from .deps import get_current_user
+from .models.admin import AdminUser
+from .models.entities import User, Conversation, Message, Feedback, MessageEvaluation
 from .routers import auth, users
 from .seed import seed_default_admin
 from .utils.security import decrypt_data, encrypt_data
@@ -15,6 +17,10 @@ from .utils.security import decrypt_data, encrypt_data
 class UserUpdate(BaseModel):
     name: Optional[str] = None
     cpf: Optional[str] = None
+
+
+class MessageEvaluationInput(BaseModel):
+    rating: Literal["positive", "negative"]
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -169,3 +175,42 @@ def create_feedback(feedback: Feedback, session: Session = Depends(get_session))
         session.commit()
         session.refresh(feedback)
         return feedback
+
+
+# Message Evaluation Endpoints (avaliação de respostas da LLM por gestores/analistas)
+@app.get("/api/v1/message-evaluations", response_model=list[MessageEvaluation])
+def list_message_evaluations(
+    session: Session = Depends(get_session),
+    _: AdminUser = Depends(get_current_user),
+):
+    return session.exec(select(MessageEvaluation)).all()
+
+
+@app.put("/api/v1/messages/{message_id}/evaluation", response_model=MessageEvaluation)
+def evaluate_message(
+    message_id: int,
+    payload: MessageEvaluationInput,
+    session: Session = Depends(get_session),
+    current_user: AdminUser = Depends(get_current_user),
+):
+    message = session.get(Message, message_id)
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    statement = select(MessageEvaluation).where(MessageEvaluation.message_id == message_id)
+    evaluation = session.exec(statement).first()
+
+    if evaluation:
+        evaluation.rating = payload.rating
+        evaluation.admin_user_id = current_user.id
+    else:
+        evaluation = MessageEvaluation(
+            message_id=message_id,
+            admin_user_id=current_user.id,
+            rating=payload.rating,
+        )
+
+    session.add(evaluation)
+    session.commit()
+    session.refresh(evaluation)
+    return evaluation

--- a/services/service_manager/app/models/entities.py
+++ b/services/service_manager/app/models/entities.py
@@ -55,3 +55,13 @@ class Feedback(SQLModel, table=True):
 
     conversation: Conversation = Relationship(back_populates="feedback")
 
+
+class MessageEvaluation(SQLModel, table=True):
+    __tablename__ = "message_evaluations"
+
+    id: Optional[int] = Field(default=None, primary_key=True, description="Unique identifier for the evaluation")
+    message_id: int = Field(foreign_key="message.id", unique=True, index=True, description="ID of the evaluated bot message")
+    admin_user_id: str = Field(foreign_key="admin_users.id", description="ID of the admin who evaluated the message")
+    rating: str = Field(description="Evaluation result: positive or negative")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Timestamp of the evaluation")
+


### PR DESCRIPTION
## Summary
- Novo modelo `MessageEvaluation` (tabela `message_evaluations`, único por `message_id`).
- `GET /api/v1/message-evaluations` lista todas as avaliações.
- `PUT /api/v1/messages/{message_id}/evaluation` faz upsert de avaliação positiva/negativa de uma resposta do bot, exige usuário autenticado.

Permite que gestores e analistas avaliem (👍/👎) as respostas da LLM no histórico de conversas, coletando dados de onde o modelo acerta/erra.

⚠️ Empilhado sobre #83 — revisar/mergear #83 primeiro.

## Test plan
- [x] PUT cria registro de avaliação na primeira chamada
- [x] PUT repetido no mesmo `message_id` atualiza (upsert) o mesmo registro
- [x] 422 ao enviar `rating` inválido (fora de positive/negative)
- [x] 401/403 sem token de autenticação