### PR TITLE
refactor: simplifica roles para Gestor e Analista

### DIFF
--- a/services/service_manager/app/deps.py
+++ b/services/service_manager/app/deps.py
@@ -5,7 +5,7 @@ from sqlmodel import Session
 
 from app import security
 from app.database import get_session
-from app.models.admin import AdminUser
+from app.models.admin import AdminUser, Role
 
 bearer_scheme = HTTPBearer()
 
@@ -23,3 +23,9 @@ def get_current_user(
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado")
     return user
+
+
+def require_gestor(current_user: AdminUser = Depends(get_current_user)) -> AdminUser:
+    if current_user.role != Role.gestor:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Acesso restrito a gestores")
+    return current_user

--- a/services/service_manager/app/models/admin.py
+++ b/services/service_manager/app/models/admin.py
@@ -5,8 +5,7 @@ from sqlmodel import Field, SQLModel
 
 
 class Role(str, enum.Enum):
-    gestor_gerencia = "gestor_gerencia"
-    gestor_analista = "gestor_analista"
+    gestor = "gestor"
     analista = "analista"
 
 

--- a/services/service_manager/app/routers/users.py
+++ b/services/service_manager/app/routers/users.py
@@ -3,7 +3,7 @@ from sqlmodel import Session, select
 
 from app import schemas, security
 from app.database import get_session
-from app.deps import get_current_user
+from app.deps import require_gestor
 from app.models.admin import AdminUser
 
 router = APIRouter(prefix="/api/v1/admin-users", tags=["admin-users"])
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/api/v1/admin-users", tags=["admin-users"])
 @router.get("", response_model=list[schemas.UserOut])
 def list_users(
     session: Session = Depends(get_session),
-    _: AdminUser = Depends(get_current_user),
+    _: AdminUser = Depends(require_gestor),
 ) -> list[AdminUser]:
     return session.exec(select(AdminUser)).all()
 
@@ -21,7 +21,7 @@ def list_users(
 def create_user(
     payload: schemas.UserCreate,
     session: Session = Depends(get_session),
-    _: AdminUser = Depends(get_current_user),
+    _: AdminUser = Depends(require_gestor),
 ) -> AdminUser:
     if session.exec(select(AdminUser).where(AdminUser.email == payload.email)).first():
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="E-mail já cadastrado")
@@ -43,7 +43,7 @@ def update_user(
     user_id: str,
     payload: schemas.UserUpdate,
     session: Session = Depends(get_session),
-    _: AdminUser = Depends(get_current_user),
+    _: AdminUser = Depends(require_gestor),
 ) -> AdminUser:
     user = session.get(AdminUser, user_id)
     if not user:
@@ -68,7 +68,7 @@ def update_user(
 def delete_user(
     user_id: str,
     session: Session = Depends(get_session),
-    _: AdminUser = Depends(get_current_user),
+    _: AdminUser = Depends(require_gestor),
 ) -> None:
     user = session.get(AdminUser, user_id)
     if not user:

--- a/services/service_manager/app/seed.py
+++ b/services/service_manager/app/seed.py
@@ -1,5 +1,6 @@
 import os
 
+from sqlalchemy import text
 from sqlmodel import Session, select
 
 from app import security
@@ -7,6 +8,15 @@ from app.models.admin import AdminUser, Role
 
 
 def seed_default_admin(session: Session) -> None:
+    # Migra valores antigos do enum Role (gestor_gerencia/gestor_analista -> gestor).
+    # ADD VALUE precisa ser commitado antes de poder ser usado em outra instrução.
+    session.exec(text("ALTER TYPE role ADD VALUE IF NOT EXISTS 'gestor'"))
+    session.commit()
+    session.exec(
+        text("UPDATE admin_users SET role = 'gestor' WHERE role::text IN ('gestor_gerencia', 'gestor_analista')")
+    )
+    session.commit()
+
     if session.exec(select(AdminUser)).first():
         return
 
@@ -17,7 +27,7 @@ def seed_default_admin(session: Session) -> None:
         name="Administrador",
         email=email,
         hashed_password=security.hash_password(password),
-        role=Role.gestor_gerencia,
+        role=Role.gestor,
     )
     session.add(admin)
     session.commit()


### PR DESCRIPTION
## Summary
- Simplifica o enum `Role` de 3 valores (`gestor_gerencia`, `gestor_analista`, `analista`) para 2 (`gestor`, `analista`).
- Migração do enum nativo do Postgres em `seed.py` (`ALTER TYPE role ADD VALUE`, commit separado, depois `UPDATE` migrando registros antigos).
- Nova dependência `require_gestor` em `deps.py`; todas as rotas de `/api/v1/admin-users` agora exigem role `gestor`.

Gestor mantém acesso total (incluindo gestão de usuários); Analista fica restrito a dashboard e conversas.

Nota: conteúdo do PR #83, que foi mergeado na branch `feature/clientes-update-cpf-nome` em vez de `main` (base já tinha sido mergeado em #82). Este PR traz essas mudanças para `main`.

## Test plan
- [x] Rebuild do service-manager: migração do enum executada com sucesso (ALTER TYPE + UPDATE + COMMIT)
- [x] Login retorna `role: "gestor"` para o admin seed
- [x] Usuário com role `analista` recebe 403 em `/api/v1/admin-users`, 200 em `/api/v1/conversations`