### PR TITLE
feat: atendimento humano ao vivo (handover) + avaliacao no encerramento

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   db:
     image: postgres:16-alpine
     container_name: assistente_db
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-admin}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin123}
@@ -13,6 +14,7 @@ services:
 
   pln-pipeline:
     container_name: pln_pipeline
+    restart: unless-stopped
     build:
       context: ./services/pln_pipeline
       dockerfile: Dockerfile
@@ -23,6 +25,7 @@ services:
 
   service-manager:
     container_name: service_manager
+    restart: unless-stopped
     build:
       context: ./services/service_manager
       dockerfile: Dockerfile
@@ -34,6 +37,8 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-change-me}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@procon.sp.gov.br}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin123}
+      BOT_URL: ${BOT_URL:-http://whatsapp-bot:8003}
+      BOT_SECRET: ${BOT_SECRET:-dev-bot-secret-change-me}
     depends_on:
       - db
     networks:
@@ -41,6 +46,7 @@ services:
 
   whatsapp-bot:
     container_name: whatsapp_bot
+    restart: unless-stopped
     build:
       context: ./services/whatsapp_bot
       dockerfile: Dockerfile
@@ -49,6 +55,9 @@ services:
     environment:
       PLN_URL: http://pln-pipeline:8001/api/fasttext/knn
       MANAGER_URL: http://service-manager:8002/api/v1
+      BOT_SECRET: ${BOT_SECRET:-dev-bot-secret-change-me}
+    volumes:
+      - wa_session:/app/.wwebjs_auth
     networks:
       - assistente-whatsapp-net
 
@@ -58,3 +67,4 @@ networks:
 
 volumes:
   postgres_data:
+  wa_session:

--- a/services/service_manager/app/main.py
+++ b/services/service_manager/app/main.py
@@ -1,6 +1,9 @@
+import os
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Literal, Optional
 
+import httpx
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -23,6 +26,30 @@ class UserUpdate(BaseModel):
 
 class MessageEvaluationInput(BaseModel):
     rating: Literal["positive", "negative"]
+
+
+class AgentMessageInput(BaseModel):
+    content: str
+
+
+BOT_URL = os.getenv("BOT_URL", "http://whatsapp-bot:8003")
+BOT_SECRET = os.getenv("BOT_SECRET", "dev-bot-secret-change-me")
+
+
+def _chat_id(user: User) -> str:
+    """Mirror the bot's chatId resolution: prefer WhatsApp ID, fall back to phone JID."""
+    return user.whatsapp_id or f"{user.phone}@c.us"
+
+
+def send_whatsapp_message(chat_id: str, text: str) -> None:
+    """Push an outbound WhatsApp message through the bot. Raises on failure."""
+    resp = httpx.post(
+        f"{BOT_URL}/send",
+        json={"chatId": chat_id, "text": text},
+        headers={"X-Bot-Secret": BOT_SECRET},
+        timeout=15.0,
+    )
+    resp.raise_for_status()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -238,6 +265,114 @@ def reset_failures(conversation_id: int, session: Session = Depends(get_session)
         raise HTTPException(status_code=404, detail="Conversation not found")
     
     conversation.failed_attempts = 0
+    session.add(conversation)
+    session.commit()
+    session.refresh(conversation)
+    return conversation
+
+
+# Live Handover Endpoints (analyst takes over the conversation from the dashboard)
+@app.post("/api/v1/conversations/{conversation_id}/takeover", response_model=Conversation)
+def takeover_conversation(
+    conversation_id: int,
+    session: Session = Depends(get_session),
+    current_user: AdminUser = Depends(get_current_user),
+):
+    conversation = session.get(Conversation, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    if conversation.status == "closed":
+        raise HTTPException(status_code=409, detail="Conversation already closed")
+    if conversation.assigned_admin_id and conversation.assigned_admin_id != current_user.id:
+        raise HTTPException(status_code=409, detail="Conversation already taken by another agent")
+
+    conversation.status = "human_handover"
+    conversation.assigned_admin_id = current_user.id
+    conversation.updated_at = datetime.now(timezone.utc)
+    session.add(conversation)
+    session.commit()
+    session.refresh(conversation)
+    return conversation
+
+
+@app.post("/api/v1/conversations/{conversation_id}/agent-message", response_model=Message)
+def agent_message(
+    conversation_id: int,
+    payload: AgentMessageInput,
+    session: Session = Depends(get_session),
+    current_user: AdminUser = Depends(get_current_user),
+):
+    conversation = session.get(Conversation, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.status != "human_handover":
+        raise HTTPException(status_code=409, detail="Conversation is not under human handover")
+    # Handover can be reached without an explicit takeover (e.g. the analyst replied
+    # directly in WhatsApp, which the bot detects and flips to human_handover).
+    # Claim it for the first agent who sends from the dashboard.
+    if conversation.assigned_admin_id is None:
+        conversation.assigned_admin_id = current_user.id
+    elif conversation.assigned_admin_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Conversation assigned to another agent")
+
+    user = session.get(User, conversation.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="Conversation user not found")
+
+    # Deliver to WhatsApp first; only persist if it actually went out.
+    try:
+        send_whatsapp_message(_chat_id(user), payload.content)
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to deliver message via bot: {exc}")
+
+    message = Message(conversation_id=conversation_id, role="agent", content=payload.content)
+    conversation.updated_at = datetime.now(timezone.utc)
+    session.add(message)
+    session.add(conversation)
+    session.commit()
+    session.refresh(message)
+    return message
+
+
+@app.post("/api/v1/conversations/{conversation_id}/release", response_model=Conversation)
+def release_conversation(
+    conversation_id: int,
+    to_bot: bool = False,
+    session: Session = Depends(get_session),
+    current_user: AdminUser = Depends(get_current_user),
+):
+    """End the live handover. Default: send a closing message + ask for a 1-5 rating
+    (status -> awaiting_feedback, bot collects the rating and closes). Pass to_bot=true
+    to instead hand control back to the bot (status -> open)."""
+    conversation = session.get(Conversation, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.assigned_admin_id and conversation.assigned_admin_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Conversation assigned to another agent")
+
+    conversation.assigned_admin_id = None
+    conversation.failed_attempts = 0
+    if to_bot:
+        conversation.status = "open"
+    else:
+        # Close out: notify the client and ask for a satisfaction rating.
+        # The bot's awaiting_feedback handler collects the 1-5 reply and closes.
+        conversation.status = "awaiting_feedback"
+        conversation.patience_msg_sent = False
+        user = session.get(User, conversation.user_id)
+        if user:
+            closing = (
+                "Seu atendimento foi encerrado pelo nosso atendente. "
+                "Para finalizar, avalie o atendimento com uma nota de *1 a 5*."
+            )
+            try:
+                send_whatsapp_message(_chat_id(user), closing)
+            except httpx.HTTPError as exc:
+                # Best-effort: still transition state so the dashboard reflects the end.
+                print(f"[release] failed to send closing message: {exc}")
+            session.add(Message(conversation_id=conversation_id, role="system", content=closing))
+    conversation.updated_at = datetime.now(timezone.utc)
     session.add(conversation)
     session.commit()
     session.refresh(conversation)

--- a/services/service_manager/app/models/entities.py
+++ b/services/service_manager/app/models/entities.py
@@ -30,6 +30,7 @@ class Conversation(SQLModel, table=True):
     protocol: str = Field(index=True, unique=True, description="Unique protocol number for the conversation")
     status: str = Field(default="open", description="Current status of the conversation: open, closed, archived, waiting_human, human_handover, confirming_closure, awaiting_feedback")
     failed_attempts: int = Field(default=0, description="Consecutive failed understanding attempts by the bot")
+    assigned_admin_id: Optional[str] = Field(default=None, foreign_key="admin_users.id", description="Admin who took over this conversation (live handover)")
     patience_msg_sent: bool = Field(default=False, description="Whether the patience message has been sent for this conversation")
     is_onboarded: bool = Field(default=False, description="Whether the user has completed onboarding for THIS specific conversation")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Timestamp of conversation creation")
@@ -43,7 +44,7 @@ class Conversation(SQLModel, table=True):
 class Message(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True, description="Unique identifier for the message")
     conversation_id: int = Field(foreign_key="conversation.id", description="ID of the conversation this message belongs to")
-    role: str = Field(description="Role of the message sender: user, bot, system")  # user, bot, system
+    role: str = Field(description="Role of the message sender: user, bot, system, agent")  # user, bot, system, agent
     content: str = Field(description="Content of the message")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Timestamp of the message")
 

--- a/services/service_manager/requirements.txt
+++ b/services/service_manager/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 sqlmodel==0.0.22
 psycopg2-binary==2.9.9
+httpx==0.27.2
 python-dotenv==1.0.1
 cryptography==42.0.5
 

--- a/services/whatsapp_bot/index.js
+++ b/services/whatsapp_bot/index.js
@@ -5,9 +5,11 @@ const express = require('express');
 const axios = require('axios');
 
 const app = express();
+app.use(express.json());
 const PORT = 8003;
 const PLN_URL = process.env.PLN_URL || 'http://pln-pipeline:8001/api/fasttext/knn';
 const MANAGER_URL = process.env.MANAGER_URL || 'http://service-manager:8002/api/v1';
+const BOT_SECRET = process.env.BOT_SECRET || 'dev-bot-secret-change-me';
 
 let latestQR = null;
 const pendingBotMessages = new Set();
@@ -27,6 +29,19 @@ async function botSend(chatId, text) {
 }
 
 app.get('/api/v1/health', (req, res) => res.json({ status: 'ok', service: 'whatsapp-bot (node)' }));
+
+// Outbound send: used by service_manager when an analyst replies from the dashboard (live handover).
+app.post('/send', async (req, res) => {
+    if (req.headers['x-bot-secret'] !== BOT_SECRET) return res.status(401).json({ error: 'unauthorized' });
+    const { chatId, text } = req.body || {};
+    if (!chatId || !text) return res.status(400).json({ error: 'chatId and text required' });
+    try {
+        await botSend(chatId, text);
+        res.json({ status: 'sent' });
+    } catch (e) {
+        res.status(500).json({ error: 'send failed', detail: String(e) });
+    }
+});
 app.get('/qr', async (req, res) => {
     if (!latestQR) return res.status(404).send('<h2>Aguarde o QR Code...</h2>');
     const pngBuffer = await QRCode.toBuffer(latestQR, { scale: 8 });
@@ -118,18 +133,27 @@ async function startMonitor() {
     }, 60000);
 }
 
-const client = new Client({ authStrategy: new LocalAuth(), puppeteer: { executablePath: '/usr/bin/chromium', args: ['--no-sandbox'] } });
+const client = new Client({
+    authStrategy: new LocalAuth(),
+    puppeteer: { executablePath: '/usr/bin/chromium', args: ['--no-sandbox'] },
+    // Chromium can stall briefly during WhatsApp Web sync; give CDP calls more room before timing out.
+    protocolTimeout: 120000,
+});
 
 client.on('qr', (qr) => { latestQR = qr; qrcode.generate(qr, { small: true }); });
 client.on('ready', () => { latestQR = null; console.log('Bot pronto!'); startMonitor(); });
+client.on('disconnected', (reason) => console.error('[Client] desconectado:', reason));
+
+// A single Chromium/CDP hiccup must not take the whole bot down.
+process.on('unhandledRejection', (err) => console.error('[unhandledRejection]', err));
 
 // 1. EVENTO: VOCÊ FALANDO
 client.on('message_create', async (msg) => {
-    if (!msg.fromMe) return; 
-    const chat = await msg.getChat();
-    if (chat.isGroup) return;
-
+    if (!msg.fromMe) return;
     try {
+        const chat = await msg.getChat();
+        if (chat.isGroup) return;
+
         const contact = await client.getContactById(msg.to);
         const whatsappId = contact.id._serialized;
         // Extrai apenas os números do ID (antes do @) para garantir que temos o telefone real
@@ -161,9 +185,10 @@ client.on('message_create', async (msg) => {
 
 // 2. EVENTO: CLIENTE FALANDO
 client.on('message', async (msg) => {
+  try {
     const chat = await msg.getChat();
     if (chat.isGroup) return;
-    
+
     const contact = await msg.getContact();
     const whatsappId = contact.id._serialized;
     const phone = whatsappId.split('@')[0].replace(/\D/g, '');
@@ -239,7 +264,13 @@ client.on('message', async (msg) => {
             await botReply(msg, 'Olá! Sou o assistente virtual do Procon Jacareí. Antes de continuar, preciso confirmar seus dados.\n\nQual o seu nome completo?');
         } else {
             await saveMessage(c.id, 'user', msg.body);
-            const pln = await axios.post(PLN_URL, { raw_text: msg.body }, { timeout: 15000 });
+            let pln;
+            try {
+                pln = await axios.post(PLN_URL, { raw_text: msg.body }, { timeout: 15000 });
+            } catch (e) {
+                console.error('[PLN indisponível]', e?.message || e);
+                return await botReply(msg, 'Estou com uma instabilidade técnica no momento. Por favor, tente novamente em instantes.');
+            }
             let reply = pln.data.class_response;
             let isFallback = pln.data.is_fallback;
 
@@ -262,6 +293,9 @@ client.on('message', async (msg) => {
             await botReply(msg, reply);
         }
     }
+  } catch (e) {
+    console.error('[message handler]', e?.message || e);
+  }
 });
 
 client.initialize();


### PR DESCRIPTION
## O que
Habilita o analista assumir a conversa pelo painel quando o bot escala (3 falhas -> `waiting_human`) e conversar ao vivo com o cliente via WhatsApp.

## Backend
- **service_manager**: endpoints autenticados `POST /conversations/{id}/takeover`, `/agent-message`, `/release`.
- `Conversation.assigned_admin_id` (FK `admin_users`); `Message.role` aceita `agent` e `system`.
- `agent-message` entrega via bot `/send` antes de persistir; auto-claim se a conversa estiver sem dono (ex.: handover iniciado pelo proprio analista no WhatsApp).
- `release`: encerra pedindo nota **1-5** (`status=awaiting_feedback`, bot coleta e fecha) ou devolve ao bot (`status=open`).
- **whatsapp_bot**: `POST /send` (protegido por header `X-Bot-Secret`) + `express.json()`.
- Resiliencia do bot: try/catch nos handlers, `protocolTimeout`, avisa o cliente quando o PLN cai (em vez de engolir).
- **compose**: `restart: unless-stopped` em todos os servicos + volume `wa_session` (pareamento sobrevive a restart).

## Migracao
Coluna nova `conversation.assigned_admin_id` — ambiente novo via `docker compose down -v`; em base existente rodar `ALTER TABLE conversation ADD COLUMN assigned_admin_id VARCHAR;`.