### PR TITLE
feat: comando #fallback e limpeza automatica do profile do chromium

### DIFF
--- a/services/whatsapp_bot/Dockerfile
+++ b/services/whatsapp_bot/Dockerfile
@@ -48,7 +48,8 @@ COPY package.json ./
 RUN npm install
 
 COPY . .
+RUN chmod +x entrypoint.sh
 
 EXPOSE 8003
 
-CMD ["npm", "start"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/services/whatsapp_bot/entrypoint.sh
+++ b/services/whatsapp_bot/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Chromium leaves SingletonLock/SingletonSocket/SingletonCookie behind when the
+# container is killed without a graceful shutdown, which then blocks the next
+# launch with "profile appears to be in use by another Chromium process".
+find /app/.wwebjs_auth -iname 'Singleton*' -delete 2>/dev/null || true
+
+exec npm start

--- a/services/whatsapp_bot/index.js
+++ b/services/whatsapp_bot/index.js
@@ -173,6 +173,12 @@ client.on('message_create', async (msg) => {
             return;
         }
 
+        if (msg.body === '#fallback') {
+            await axios.post(`${MANAGER_URL}/conversations/${conv.id}/update-status?status=waiting_human`);
+            await botSend(msg.to, '🔁 *Atendimento marcado como pendente para um atendente humano.*');
+            return;
+        }
+
         if (!msg.body.startsWith('!') && !msg.body.startsWith('#')) {
             if (conv.status === 'waiting_human' || conv.status === 'open' || conv.status === 'confirming_closure') {
                 console.log(`[Handover] SUCESSO! Mudando usuário ${user.id} para human_handover.`);


### PR DESCRIPTION
## Resumo
- Atendente digita `#fallback` no WhatsApp (mesmo padrao do `#finalizar`) para marcar a conversa como `waiting_human`, aparecendo no painel como pendente de atendente
- Remove locks orfaos do Chromium (`SingletonLock`/`SingletonSocket`/`SingletonCookie`) no entrypoint, evitando falha de boot apos restart/rebuild do container

## Test plan
- [x] Rebuild do container, bot reconecta sem erro de profile lock
- [x] `#fallback` enviado pelo numero do bot muda status da conversa para `waiting_human`