### PR TITLE
fix: detecta corretamente quando o RAG remoto nao encontra resposta

### DIFF
--- a/services/whatsapp_bot/index.js
+++ b/services/whatsapp_bot/index.js
@@ -283,7 +283,11 @@ client.on('message', async (msg) => {
             if (isFallback && c.failed_attempts === 1) {
                 try {
                     const rag = await axios.post('http://pln-pipeline:8001/api/rag_remote', { question: msg.body, top_k: 3 }, { timeout: 45000 });
-                    if (rag.data.answer && !rag.data.answer.includes("não encontrei")) {
+                    const ragAnswer = (rag.data.answer || '').toLowerCase();
+                    // Cobre as duas variantes que o pipeline retorna quando não acha
+                    // resposta: "Nao encontrei..." (sem chunks) e "Não encontrei..." (LLM).
+                    const ragMissed = ragAnswer.includes('nao encontrei') || ragAnswer.includes('não encontrei');
+                    if (rag.data.answer && !ragMissed) {
                         reply = "*[IA Avançada - Contingência]* " + rag.data.answer;
                         isFallback = false;
                     }


### PR DESCRIPTION
## Resumo
- A checagem `includes("não encontrei")` era case/acento-sensitive e nunca batia com as strings reais do `rag_remote` (`"Nao encontrei essa informacao no documento."` e `"Não encontrei essa informação em minha base dados..."`)
- Por isso toda resposta de contingencia era tratada como sucesso, `reset-failures` rodava sempre, e o contador de falhas nunca chegava a 3 -> fallback para atendente humano nunca disparava
- Agora compara em lowercase contra as duas variantes (com e sem acento)

## Test plan
- [x] Rebuild + restart do whatsapp-bot, sem erros
- [ ] Reproduzir 2 falhas seguidas de PLN com pergunta fora da base -> RAG retorna "não encontrei" -> failed_attempts incrementa normalmente -> 3a falha leva a waiting_human